### PR TITLE
Automatically publish draft posts on the correct date

### DIFF
--- a/.github/bot.py
+++ b/.github/bot.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+import glob
+import pprint
+import sys
+import datetime
+from ruamel.yaml import YAML
+
+yaml = YAML(typ="rt")
+yaml_str = YAML(typ=["rt", "string"])
+
+
+class QuartoPost:
+    def __init__(self, header, content):
+        self.header = header  # dict
+        self.content = content  # str
+
+    @classmethod
+    def from_filename(cls, filename):
+        with open(filename, "r") as infile:
+            line = next(infile)
+            assert line == "---\n"
+            line = next(infile)
+            yaml_lst = list()
+            while line != "---\n":
+                yaml_lst.append(line)
+                line = next(infile)
+            content = infile.read()
+            yaml_str = "".join(yaml_lst)
+            header = yaml.load(yaml_str)
+        return cls(header=header, content=content)
+
+    def to_str(self):
+        return "\n".join(
+            [
+                "---",
+                yaml_str.dump_to_string(self.header),
+                "---",
+                self.content,
+            ]
+        )
+
+    def write(self, filename):
+        with open(filename, "w") as outfile:
+            outfile.write(self.to_str())
+
+    @property
+    def date(self):
+        return datetime.datetime.strptime(self.header["date"], "%Y-%m-%d")
+
+    @property
+    def is_due(self):
+        return self.date <= datetime.datetime.today()
+
+    @property
+    def is_draft(self):
+        return "draft" in self.header and self.header["draft"]
+
+    def publish(self):
+        newly_published = False
+        if self.is_due and self.is_draft:
+            self.header["draft"] = False
+            newly_published = True
+        return newly_published
+
+
+def main(glob_path):
+    for fp in glob.glob(glob_path, recursive=True):
+        qp = QuartoPost.from_filename(fp)
+        if qp.publish():
+            print("PUBLISHING: ", qp.header["title"])
+            qp.write(fp)
+
+
+def examples():
+    qp = QuartoPost.from_filename(
+        "/Users/sovacool/projects/neighborhood-scientist/neighborhoodscientist.org/posts/2025/introducing-your-neighborhood-scientist/index.qmd"
+    )
+    print(qp.date)
+    print(datetime.datetime.today())
+    print(qp.is_due)
+
+
+if __name__ == "__main__":
+    main("./posts/**/*.qmd")

--- a/.github/requirements.txt
+++ b/.github/requirements.txt
@@ -1,0 +1,2 @@
+ruamel.yaml
+ruamel.yaml.string

--- a/.github/workflows/publish-draft.yml
+++ b/.github/workflows/publish-draft.yml
@@ -38,13 +38,13 @@ jobs:
         id: open-pr
         run: |
           python .github/bot.py
-          if [[ $(git diff --exit-code . ) ]]; then
+          if [[ $(git diff --exit-code ./posts ) ]]; then
               changes=true
               today=$(date +'%Y-%m-%d')
               branch="post/${today}"
               echo "branch=$branch" >> $GITHUB_OUTPUT
               git switch -c $branch
-              git add .
+              git add ./posts
               git commit -m "🤖 publish post(s) for ${today}" || echo 'nothing to commit'
               git push
               gh pr create --fill

--- a/.github/workflows/publish-draft.yml
+++ b/.github/workflows/publish-draft.yml
@@ -1,0 +1,65 @@
+name: publish-draft
+# if there are any drafts to be posted today, publish them!
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "20 6 * * *"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.11
+
+      - name: Install Python packages
+        run: |
+          pip install --upgrade pip -r .github/requirements.txt
+
+      - name: Git config
+        run: |
+          git config --local user.email "bot@neighborhoodscientist.org"
+          git config --local user.name "yns-bot"
+          git config push.default upstream
+          git config push.autoSetupRemote true
+
+      - name: Open pull request to publish any drafts due today
+        id: open-pr
+        run: |
+          python .github/bot.py
+          if [[ $(git diff --exit-code . ) ]]; then
+              changes=true
+              today=$(date +'%Y-%m-%d')
+              branch="post/${today}"
+              echo "branch=$branch" >> $GITHUB_OUTPUT
+              git switch -c $branch
+              git add .
+              git commit -m "🤖 publish post(s) for ${today}" || echo 'nothing to commit'
+              git push
+              gh pr create --fill
+              gh pr merge --auto --merge
+          else
+              changes=false
+          fi
+          echo "changes=$changes" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN_BOT }}
+
+      - name: Approve PR
+        if: steps.open-pr.outputs.changes == 'true'
+        run: |
+          gh pr review $BRANCH --approve
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN_KLS }}
+          BRANCH: ${{ steps.open-pr.outputs.branch }}


### PR DESCRIPTION
For any quarto files in `posts/`, if `draft` is `true` and the post's date is on or before today, this bot will set draft to false, open a PR, and automatically merge it so the post will be published today.

resolves https://github.com/neighborhood-scientist/sandbox/issues/4

## Checklist

- [x] Does the rendered site look good?
  > Go to the log for the latest run of the `quarto-build-site` workflow,
  > click on the `website-html` artifact to download it, unzip it, and view
  > the rendered html files in your browser.
